### PR TITLE
fix: Use transform instead of margin for improved performance

### DIFF
--- a/src/components/BlockTimeline.vue
+++ b/src/components/BlockTimeline.vue
@@ -16,9 +16,7 @@
         <div
           class="blocks"
           :style="{
-            'margin-left': `${(
-              getTimeSinceLastBlock(chain) * 40n
-            ).toString()}px`,
+            'transform': `translateX(${(getTimeSinceLastBlock(chain) * 40n).toString()}px)`
           }"
         >
           <TransitionGroup name="blocks">


### PR DESCRIPTION
## What it solves

Uses css `transform` instead of `margin` to move the blocks around. This results in better performance because it only affects the composite layer instead of repainting the DOM (see https://web.dev/articles/rendering-performance?hl=en#the_pixel_pipeline).

## How to test

Open the app and observe that your device is quiet and doesn't heat up anymore.